### PR TITLE
docker: pin base image versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
   - pip
 
 python:
-  - 2.7
+  - 3.6
 
 services:
   - docker

--- a/eventselection/Dockerfile
+++ b/eventselection/Dockerfile
@@ -1,4 +1,4 @@
-FROM atlas/analysisbase:latest
+FROM atlas/analysisbase:21.2.51
 ADD . /analysis/src
 WORKDIR /analysis/build
 RUN source ~/release_setup.sh &&  \

--- a/statanalysis/Dockerfile
+++ b/statanalysis/Dockerfile
@@ -1,6 +1,6 @@
-FROM atlas/analysisbase
+FROM atlas/analysisbase:21.2.51
 ADD . /code
-RUN sudo sh -c "source /home/atlas/release_setup.sh && pip install hftools"
+RUN sudo sh -c "source /home/atlas/release_setup.sh && pip install hftools==0.0.6"
 USER root
 RUN sudo usermod -G root atlas
 USER atlas


### PR DESCRIPTION
* Pins ATLAS base docker images which makes the workflow to produce
  plots again. (closes #21)

Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>