### PR TITLE
workflow: force uid=500 for runtime workflow user

### DIFF
--- a/workflow/steps.yml
+++ b/workflow/steps.yml
@@ -20,6 +20,8 @@ eventselection:
   environment:
     environment_type: 'docker-encapsulated'
     image: reanahub/reana-demo-atlas-recast-eventselection
+    resources:
+      - kubernetes_uid: 500
 
 statanalysis:
   process:
@@ -44,3 +46,5 @@ statanalysis:
   environment:
     environment_type: 'docker-encapsulated'
     image: reanahub/reana-demo-atlas-recast-statanalysis
+    resources:
+      - kubernetes_uid: 500


### PR DESCRIPTION
* Adds forcing of Kubernetes runtime user ID to 500, which is necessary
  to match the example container image.  This makes the ATLAS RECAST
  example to work fully again.

Co-authored-by: Rokas Maciulaitis <rokas.maciulaitis@cern.ch>
Signed-off-by: Tibor Šimko <tibor.simko@cern.ch>