### PR TITLE
yadage: HTCondor compute backend example

### DIFF
--- a/reana-htcondorcern.yaml
+++ b/reana-htcondorcern.yaml
@@ -1,0 +1,14 @@
+version: 0.6.0
+inputs:
+  parameters:
+    did: 404958
+    xsec_in_pb: 0.00122
+    dxaod_file: https://recastwww.web.cern.ch/recastwww/data/reana-recast-demo/mc15_13TeV.123456.cap_recast_demo_signal_one.root
+  directories:
+    - workflow
+workflow:
+  type: yadage
+  file: workflow/workflow-htcondorcern.yml
+outputs:
+  files:
+    - statanalysis/fitresults/limit.png

--- a/workflow/steps-htcondorcern.yml
+++ b/workflow/steps-htcondorcern.yml
@@ -24,6 +24,7 @@ eventselection:
     resources:
       - kubernetes_uid: 500
       - compute_backend: htcondorcern
+      - htcondor_max_runtime: espresso
 
 statanalysis:
   process:
@@ -52,3 +53,4 @@ statanalysis:
     resources:
       - kubernetes_uid: 500
       - compute_backend: htcondorcern
+      - htcondor_max_runtime: espresso

--- a/workflow/steps-htcondorcern.yml
+++ b/workflow/steps-htcondorcern.yml
@@ -1,0 +1,54 @@
+eventselection:
+  process:
+    process_type: interpolated-script-cmd
+    interpreter: bash
+    script: |
+      source /home/atlas/release_setup.sh
+      source /analysis/build/x86*/setup.sh
+
+      cat << 'EOF' > recast_xsecs.txt
+      id/I:name/C:xsec/F:kfac/F:eff/F:relunc/F
+      {did} {name} {xsec_in_pb} 1.0 1.0 1.0
+      EOF
+
+      echo {dxaod_file} > recast_inputs.txt
+      myEventSelection {submitDir} recast_inputs.txt recast_xsecs.txt {lumi_in_ifb}
+  publisher:
+    publisher_type: interpolated-pub
+    publish:
+      histfile: '{submitDir}/hist-sample.root'
+  environment:
+    environment_type: 'docker-encapsulated'
+    image: reanahub/reana-demo-atlas-recast-eventselection
+    imagetag: '1.0'
+    resources:
+      - kubernetes_uid: 500
+      - compute_backend: htcondorcern
+
+statanalysis:
+  process:
+    process_type: interpolated-script-cmd
+    interpreter: bash
+    script: |
+      source /home/atlas/release_setup.sh
+
+      python /code/make_ws.py {data_file} {signal_file} {background_file}
+      mkdir -p {resultdir}
+      python /code/plot.py results/meas_combined_meas_model.root {resultdir}/pre.png {resultdir}/post.png
+      python /code/set_limit.py results/meas_combined_meas_model.root \
+             {resultdir}/limit.png {resultdir}/limit_data.json \
+             {resultdir}/limit_data_nomsignal.json
+  publisher:
+    publisher_type: interpolated-pub
+    publish:
+      pre:    '{resultdir}/pre.png'
+      post:   '{resultdir}/post.png'
+      limit:  '{resultdir}/limit_data.json'
+      nomsig: '{resultdir}/limit_data_nomsignal.json'
+  environment:
+    environment_type: 'docker-encapsulated'
+    image: reanahub/reana-demo-atlas-recast-statanalysis
+    imagetag: '1.0'
+    resources:
+      - kubernetes_uid: 500
+      - compute_backend: htcondorcern

--- a/workflow/workflow-htcondorcern.yml
+++ b/workflow/workflow-htcondorcern.yml
@@ -1,0 +1,37 @@
+# Note that if you are working on the analysis development locally, i.e. outside
+# of the REANA platform, you can proceed as follows:
+#
+#   $ virtualenv ~/.virtualenvs/yadage
+#   $ source ~/.virtualenvs/yadage/bin/activate
+#   $ pip install yadage
+#   $ yadage-run _run workflow/workflow.yml ./workflow/test_inputs/inp1.yml
+#   $ ls -l _run/statanalysis/fitresults/*.png
+#   -rw-r--r-- 1 root root 17053 Jun 17 15:16 _run/statanalysis/fitresults/limit.png
+#   -rw-r--r-- 1 root root 10120 Jun 17 15:16 _run/statanalysis/fitresults/post.png
+#   -rw-r--r-- 1 root root 10142 Jun 17 15:16 _run/statanalysis/fitresults/pre.png
+#   $ ls -l _run/statanalysis/fitresults/limit_data.json
+#   -rw-r--r-- 1 root root 174 Jun 17 15:16 _run/statanalysis/fitresults/limit_data.json
+
+stages:
+  - name: eventselection
+    dependencies: [init]
+    scheduler:
+      scheduler_type: singlestep-stage
+      parameters:
+        name: recast_sample
+        did: {step: init, output: did}
+        xsec_in_pb: {step: init, output: xsec_in_pb}
+        dxaod_file: {step: init, output: dxaod_file}
+        lumi_in_ifb: 30.0
+        submitDir: '{workdir}/submitDir'
+      step: {$ref: 'workflow/steps-htcondorcern.yml#/eventselection'}
+  - name: statanalysis
+    dependencies: [eventselection]
+    scheduler:
+      scheduler_type: singlestep-stage
+      parameters:
+        data_file: /code/data/data.root
+        signal_file: {step: eventselection, output: histfile}
+        background_file: /code/data/background.root
+        resultdir: '{workdir}/fitresults'
+      step: {$ref: 'workflow/steps-htcondorcern.yml#/statanalysis'}


### PR DESCRIPTION
(1) The first step fails due to DNS troubles:

```
Running sample: sample
Processing File: https://recastwww.web.cern.ch/recastwww/data/reana-recast-demo/mc15_13TeV.123456.cap_recast_demo_signal_one.root
DavixOpen                 ERROR   can not open file with davix: Failure Domain name resolution failed after 3 attempts (5)
/build2/atnight/localbuilds/nightlies/21.2/AnalysisBase/athena/PhysicsAnalysis/D3PDTools/SampleHandler/Root/ToolsOther.cxx:68:exception: failed to open file: https://recastwww.web.cern.ch/recastwww/data/reana-recast-demo/mc15_13TeV.123456.cap_recast_demo_signal_one.root
[Error] Execution failed with error code: 134
```

Need to check DNS on HTC.

(2) The second step seems to start, and fails with:

```
==> Step: statanalysis
==> Compute backend: HTCondor
==> Job ID: 5619190
Job logs of 5619190 were not found. [Errno 2] No such file or directory: '/var/reana/users/b57e902f-fd11-4681-8a94-4318ae05d2ca/workflows/b36d29f9-9d89-4c01-a21b-ec5bc0140955/reana_job.5619190.0.err'
```

Since the first step failed, the second should not even be started? Perhaps due to:

```
2021-02-21 10:03:48,483 | adage.controllerutils | MainThread | INFO | no nodes can be run anymore and no rules are applicable
2021-02-21 10:03:48,483 | adage.controllerutils | MainThread | INFO | no nodes can be run anymore and no rules are applicable
2021-02-21 10:03:48,483 | adage | MainThread | ERROR | some weird exception caught in adage process loop
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/adage/__init__.py", line 51, in run_polling_workflow
    for stepnum, controller in enumerate(coroutine):
  File "/usr/local/lib/python3.8/site-packages/adage/pollingexec.py", line 89, in adage_coroutine
    raise RuntimeError('workflow finished but failed')
RuntimeError: workflow finished but failed
2021-02-21 10:03:48,485 | adage | MainThread | ERROR | node: </statanalysis:0|failed|known> failed. reason: unknown
2021-02-21 10:03:48,485 | adage | MainThread | INFO | unsubmittable: 0 | submitted: 0 | successful: 2 | failed: 1 | total: 3 | open rules: 0 | applied rules: 3
2021-02-21 10:03:59,304 | reana-workflow-engine-yadage | MainThread | INFO | sending progress information
2021-02-21 10:03:59,314 | reana-workflow-engine-yadage | MainThread | INFO | sending to REANA
```

Also:

```
2021-02-21 10:03:59,316 | reana-workflow-engine-yadage | MainThread | INFO | Finalizing the progress tracking for: <yadage.wflow.YadageWorkflow object at 0x7fe9f7c277f0>
2021-02-21 10:03:59,318 | yadage.steering_api | MainThread | INFO | done. dumping workflow to disk.
2021-02-21 10:03:59,322 | reana-workflow-engine-yadage | MainThread | ERROR | Workflow failed: workflow finished but failed
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/reana_workflow_engine_yadage/cli.py", line 156, in run_yadage_workflow
    ys.adage_argument(
  File "/usr/local/lib/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "/usr/local/lib/python3.8/site-packages/yadage/steering_api.py", line 110, in steering_ctx
    execute_steering(
  File "/usr/local/lib/python3.8/site-packages/yadage/steering_api.py", line 60, in execute_steering
    ys.run_adage(backend)
  File "/usr/local/lib/python3.8/site-packages/yadage/steering_object.py", line 100, in run_adage
    adage.rundag(controller=self.controller, **self.adage_kwargs)
  File "/usr/local/lib/python3.8/site-packages/adage/__init__.py", line 137, in rundag
    run_polling_workflow(controller, coroutine, update_interval, trackerlist, maxsteps)
  File "/usr/local/lib/python3.8/site-packages/adage/__init__.py", line 51, in run_polling_workflow
    for stepnum, controller in enumerate(coroutine):
  File "/usr/local/lib/python3.8/site-packages/adage/pollingexec.py", line 89, in adage_coroutine
    raise RuntimeError('workflow finished but failed')
RuntimeError: workflow finished but failed
2021-02-21 10:03:59,325 | root | MainThread | ERROR | Error while publishing channel disconnected
2021-02-21 10:03:59,325 | root | MainThread | INFO | Retry in 0 seconds.
```