### PR TITLE
workflows: less strict memory limits

### DIFF
--- a/reana-debug.yaml
+++ b/reana-debug.yaml
@@ -16,7 +16,7 @@ workflow:
     steps:
       - name: eventselection
         environment: reanahub/reana-demo-atlas-recast-eventselection:1.0
-        kubernetes_memory_limit: '64Mi'
+        kubernetes_memory_limit: '256Mi'
         kubernetes_uid: 500
         commands:
           - >
@@ -29,7 +29,7 @@ workflow:
 
       - name: statanalysis
         environment: reanahub/reana-demo-atlas-recast-statanalysis:1.0
-        kubernetes_memory_limit: '64Mi'
+        kubernetes_memory_limit: '256Mi'
         kubernetes_uid: 500
         commands:
           - >

--- a/workflow/steps.yml
+++ b/workflow/steps.yml
@@ -22,7 +22,7 @@ eventselection:
     image: reanahub/reana-demo-atlas-recast-eventselection
     imagetag: '1.0'
     resources:
-      - kubernetes_memory_limit: '64Mi'
+      - kubernetes_memory_limit: '256Mi'
       - kubernetes_uid: 500
 
 statanalysis:
@@ -50,5 +50,5 @@ statanalysis:
     image: reanahub/reana-demo-atlas-recast-statanalysis
     imagetag: '1.0'
     resources:
-      - kubernetes_memory_limit: '64Mi'
+      - kubernetes_memory_limit: '256Mi'
       - kubernetes_uid: 500


### PR DESCRIPTION
Uses 256Mi instead of 64Mi which was not enough on some REANA
installations such as the the REANA production server at CERN.