### PR TITLE
docs: add Launch on REANA badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,13 +3,16 @@
 ==============================
 
 .. image:: https://github.com/reanahub/reana-demo-atlas-recast/workflows/CI/badge.svg
-      :target: https://github.com/reanahub/reana-demo-atlas-recast/actions
+   :target: https://github.com/reanahub/reana-demo-atlas-recast/actions
 
 .. image:: https://badges.gitter.im/Join%20Chat.svg
    :target: https://gitter.im/reanahub/reana?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
 
 .. image:: https://img.shields.io/github/license/reanahub/reana-demo-atlas-recast.svg
    :target: https://raw.githubusercontent.com/reanahub/reana-demo-atlas-recast/master/LICENSE
+
+.. image:: https://www.reana.io/static/img/badges/launch-on-reana-at-cern.svg
+   :target: https://reana.cern.ch/launch?url=https%3A%2F%2Fgithub.com%2Freanahub%2Freana-demo-atlas-recast&name=reana-demo-atlas-recast
 
 About
 =====
@@ -163,6 +166,22 @@ as for µ=1.
 
 Running the example on REANA cloud
 ==================================
+
+There are two ways to execute this analysis example on REANA.
+
+If you would like to simply launch this analysis example on the REANA instance
+at CERN and inspect its results using the web interface, please click on
+the following badge:
+
+.. raw:: html
+
+   <a href="https://reana.cern.ch/launch?url=https%3A%2F%2Fgithub.com%2Freanahub%2Freana-demo-atlas-recast&name=reana-demo-atlas-recast">
+    <img src="https://www.reana.io/static/img/badges/launch-on-reana-at-cern.svg" />
+   </a>
+   <p></p>
+
+If you would like a step-by-step guide on how to use the REANA command-line
+client to launch this analysis example, please read on.
 
 We start by creating a `reana.yaml <reana.yaml>`_ file describing the above
 analysis structure with its inputs, code, runtime environment, computational


### PR DESCRIPTION
closes #40

I want to start with a simpler demo where we have only a single `reana.yaml`. If this PR looks good, I can proceed with other simple demos and add badges there.

To view the results, you can click on the latest commit, explore all files, and go to README.md. The badge will be on top.