### PR TITLE
chore: Update REANA platform version to v0.9.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,7 @@ workflow steps and expected outputs:
 
 .. code-block:: yaml
 
-    version: 0.3.0
+    version: 0.9.0
     inputs:
       parameters:
         did: 404958

--- a/reana-debug.yaml
+++ b/reana-debug.yaml
@@ -1,4 +1,4 @@
-version: 0.6.0
+version: 0.9.0
 inputs:
   parameters:
     name: recast_sample

--- a/reana-htcondorcern.yaml
+++ b/reana-htcondorcern.yaml
@@ -1,4 +1,4 @@
-version: 0.6.0
+version: 0.9.0
 inputs:
   parameters:
     did: 404958

--- a/reana.yaml
+++ b/reana.yaml
@@ -1,4 +1,4 @@
-version: 0.6.0
+version: 0.9.0
 inputs:
   parameters:
     did: 404958


### PR DESCRIPTION
* Update from v0.6.0/0.3.0 to v0.9.0 to ensure that the workflows are valid and to signal to people using these files as references that they are v0.9.0 compatible workflows.
   - c.f. https://docs.reana.io/reference/reana-yaml/