### PR TITLE
fix(workflow): increase memory for aarch64/arm64 platforms

### DIFF
--- a/workflow/steps.yml
+++ b/workflow/steps.yml
@@ -22,7 +22,7 @@ eventselection:
     image: docker.io/reanahub/reana-demo-atlas-recast-eventselection
     imagetag: '1.0'
     resources:
-      - kubernetes_memory_limit: '256Mi'
+      - kubernetes_memory_limit: '1024Mi'
       - kubernetes_uid: 500
 
 statanalysis:
@@ -50,5 +50,5 @@ statanalysis:
     image: docker.io/reanahub/reana-demo-atlas-recast-statanalysis
     imagetag: '1.0'
     resources:
-      - kubernetes_memory_limit: '256Mi'
+      - kubernetes_memory_limit: '1024Mi'
       - kubernetes_uid: 500


### PR DESCRIPTION
Increases required Kubernetes memory so that the demo example would pass on aarch64/arm64 platforms.