### PR TITLE
fix(tests): increase acceptable runtime limit

### DIFF
--- a/tests/run-duration.feature
+++ b/tests/run-duration.feature
@@ -8,4 +8,4 @@ Feature: Run duration
 
     Scenario: The workflow terminates in a reasonable amount of time
         When the workflow execution completes
-        Then the workflow run duration should be less than 6 minutes
+        Then the workflow run duration should be less than 9 minutes


### PR DESCRIPTION
On slower hardware, or on newer hardware that did not have the container images fetched on the worker nodes yet, or on a system that was busy and ran many DEMO examples in parallel, the actual workflow execution finished successfully but was slower than on a usual idle and preloaded system. This commit allows for more liberal runtime limits in order to fit these slower testing scenarios.